### PR TITLE
fix(ci): sync tauri.conf.json version at build time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
+      # Sync tauri.conf.json version from tag (release-please extra-files is unreliable)
+      - name: Sync Tauri version
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          jq --arg v "$VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json
+          mv tmp.json src-tauri/tauri.conf.json
+          echo "Set tauri.conf.json version to $VERSION"
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [1.1.2](https://github.com/misty-step/vibe-machine/compare/v1.1.1...v1.1.2) (2026-01-16)
 
-
 ### Bug Fixes
 
-* sync versions and fix blob upload script ([98c6eb5](https://github.com/misty-step/vibe-machine/commit/98c6eb508be14d634d83957341325a76d2a6681c))
+- sync versions and fix blob upload script ([98c6eb5](https://github.com/misty-step/vibe-machine/commit/98c6eb508be14d634d83957341325a76d2a6681c))
 
 ## [1.1.1](https://github.com/misty-step/vibe-machine/compare/v1.1.0...v1.1.1) (2026-01-16)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,14 +5,7 @@
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "src-tauri/tauri.conf.json",
-          "jsonpath": "$.version"
-        }
-      ]
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Syncs tauri.conf.json version from the release tag during build
- Removes unreliable release-please extra-files config ([known issues](https://github.com/googleapis/release-please/issues/2205))

This ensures the DMG filename matches the release version (e.g., `vibe-machine_1.1.3_aarch64.dmg` instead of `vibe-machine_1.1.2_aarch64.dmg`).

## Test plan
- [ ] Merge this PR
- [ ] Verify next release build produces DMG with correct version in filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release automation to synchronize the app version earlier in the deployment workflow.
  * Simplified release configuration by removing an extra-files mapping for version bumping.

* **Documentation**
  * Minor formatting adjustment in the changelog entry for version 1.1.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->