### PR TITLE
feat: support multi-track video export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,15 @@
 
 ## [1.2.1](https://github.com/misty-step/vibe-machine/compare/v1.2.0...v1.2.1) (2026-01-17)
 
-
 ### Bug Fixes
 
-* remove unused @morphllm/morphmcp dependency (3 vulnerabilities) ([#68](https://github.com/misty-step/vibe-machine/issues/68)) ([144b152](https://github.com/misty-step/vibe-machine/commit/144b1523b025ae9dcb108162d9c4cad6d44489ce)), closes [#56](https://github.com/misty-step/vibe-machine/issues/56)
+- remove unused @morphllm/morphmcp dependency (3 vulnerabilities) ([#68](https://github.com/misty-step/vibe-machine/issues/68)) ([144b152](https://github.com/misty-step/vibe-machine/commit/144b1523b025ae9dcb108162d9c4cad6d44489ce)), closes [#56](https://github.com/misty-step/vibe-machine/issues/56)
 
 ## [1.2.0](https://github.com/misty-step/vibe-machine/compare/v1.1.3...v1.2.0) (2026-01-17)
 
-
 ### Features
 
-* add post-merge auto-update hook for local dev ([#66](https://github.com/misty-step/vibe-machine/issues/66)) ([0bc7dfd](https://github.com/misty-step/vibe-machine/commit/0bc7dfdb3c30b069e36202711bbf75541d6ed849))
+- add post-merge auto-update hook for local dev ([#66](https://github.com/misty-step/vibe-machine/issues/66)) ([0bc7dfd](https://github.com/misty-step/vibe-machine/commit/0bc7dfdb3c30b069e36202711bbf75541d6ed849))
 
 ## [1.1.3](https://github.com/misty-step/vibe-machine/compare/v1.1.2...v1.1.3) (2026-01-17)
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -59,17 +59,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onExport,
 }) => {
   const [activeTab, setActiveTab] = useState<"media" | "style" | "export">("media");
-  const exportTrack = playlist[currentTrackIndex] ?? playlist[0] ?? null;
-  const hasTrack = Boolean(exportTrack);
-  const hasSourcePath = Boolean(exportTrack?.sourcePath);
+  const hasTrack = playlist.length > 0;
+  const tracksWithSource = playlist.filter((t) => Boolean(t.sourcePath));
+  const allTracksHaveSource = tracksWithSource.length === playlist.length && playlist.length > 0;
+  const totalDuration = playlist.reduce((sum, t) => sum + (t.duration ?? 0), 0);
   const exportDisabled = isExporting || !hasTrack || !isExportSupported;
   const exportHint = !isExportSupported
     ? "Desktop app required"
     : !hasTrack
       ? "Add audio to enable export"
-      : hasSourcePath
+      : allTracksHaveSource
         ? "Choose save location"
-        : "First export will ask for source file";
+        : `${playlist.length - tracksWithSource.length} track(s) need source files`;
 
   const randomizeVibe = () => {
     const randomColor = PRESET_COLORS[Math.floor(Math.random() * PRESET_COLORS.length)];
@@ -474,22 +475,30 @@ export const Sidebar: React.FC<SidebarProps> = ({
               </div>
               <div className="flex justify-between text-[10px] font-mono text-zinc-500 uppercase">
                 <span>Dur</span>
-                <span className="text-zinc-300">{formatTime(exportTrack?.duration ?? 0)}</span>
+                <span className="text-zinc-300">{formatTime(totalDuration)}</span>
               </div>
               <div className="flex justify-between text-[10px] font-mono text-zinc-500 uppercase">
                 <span>FPS</span>
                 <span className="text-zinc-300">30</span>
               </div>
               <div className="flex justify-between text-[10px] font-mono text-zinc-500 uppercase">
-                <span>Track</span>
+                <span>Tracks</span>
                 <span className="text-zinc-300">
-                  {exportTrack?.name ? exportTrack.name : "None"}
+                  {playlist.length === 0
+                    ? "None"
+                    : playlist.length === 1
+                      ? playlist[0].name || "1 track"
+                      : `${playlist.length} tracks`}
                 </span>
               </div>
               <div className="flex justify-between text-[10px] font-mono text-zinc-500 uppercase">
                 <span>Source</span>
-                <span className={hasSourcePath ? "text-zinc-300" : "text-amber-300"}>
-                  {hasSourcePath ? "Linked" : "Needs_File"}
+                <span className={allTracksHaveSource ? "text-zinc-300" : "text-amber-300"}>
+                  {playlist.length === 0
+                    ? "—"
+                    : allTracksHaveSource
+                      ? "All_Linked"
+                      : `${tracksWithSource.length}/${playlist.length} Linked`}
                 </span>
               </div>
             </div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,6 @@ tauri-plugin-dialog = "2"
 reqwest = { version = "0.12.25", features = ["blocking", "rustls-tls"] }
 zip = "4.2.0"
 base64 = "0.22"
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"


### PR DESCRIPTION
## Summary

- Export now concatenates all playlist tracks into a single video
- Previously only the first/current track was exported, others were silently ignored
- Backend uses FFmpeg concat demuxer for lossless audio stitching
- Symphonia decodes all tracks sequentially for visualizer data

## Changes

**Rust Backend:**
- `ExportParams.audio_paths: Vec<String>` (was single `audio_path`)
- Decodes all audio files sequentially into combined buffer
- Creates temp concat list for FFmpeg's concat demuxer

**TypeScript Frontend:**
- `ExportController` collects all tracks with `sourcePath`
- Default filename shows "trackname (+N)" for multi-track exports
- Sidebar shows total duration across all tracks and "N tracks" count

## Test plan

- [ ] Add 3+ audio tracks to playlist
- [ ] Add background image
- [ ] Click Export Video
- [ ] Verify output video duration = sum of all tracks
- [ ] Verify audio plays in playlist order
- [ ] Verify visualizer responds correctly at track boundaries

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-track export: export multiple audio files into a single video.
  * Playlist-level status: shows total duration and aggregate track counts/linkage.

* **Improvements**
  * Smarter default export naming for multi-track exports.
  * Clearer export hints and prevention of export when tracks lack source files.
  * Improved progress messaging and more reliable multi-track audio processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->