### PR TITLE
ci: normalize merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Quality Checks
 
 on:
   push:
@@ -64,3 +64,14 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings
+
+  merge-gate:
+    runs-on: ubuntu-latest
+    needs: [quality, rust]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]] || \
+             [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1


### PR DESCRIPTION
## Summary
- rename the legacy CI-required check to an explicit merge gate
- keep branch protection aligned with a single stable gate job

## Testing
- GitHub Actions
