### PR TITLE
feat(site): integrate Vibe Machine with Canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,15 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings
+
+  merge-gate:
+    name: merge-gate
+    runs-on: ubuntu-latest
+    needs: [quality, rust]
+    if: always()
+    steps:
+      - name: Require all CI jobs to pass
+        run: |
+          if [ "${{ needs.quality.result }}" != "success" ] || [ "${{ needs.rust.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/crates/vibe-engine/src/lib.rs
+++ b/crates/vibe-engine/src/lib.rs
@@ -1,5 +1,5 @@
-use wasm_bindgen::prelude::*;
 use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
 
 // --- Types ---
 
@@ -31,17 +31,14 @@ pub struct VibeEngine {
 #[wasm_bindgen]
 
 impl VibeEngine {
-
     pub fn new(width: i32, height: i32) -> VibeEngine {
-
         let size = (width * height) as usize;
 
-        let pixels = vec![0xFF000000; size]; 
+        let pixels = vec![0xFF000000; size];
 
         let physics_state = vec![0.0; 64];
 
         VibeEngine {
-
             width,
 
             height,
@@ -49,143 +46,93 @@ impl VibeEngine {
             pixels,
 
             physics_state,
-
         }
-
     }
 
-
-
     pub fn resize(&mut self, width: i32, height: i32) {
-
         self.width = width;
 
         self.height = height;
 
         self.pixels.resize((width * height) as usize, 0xFF000000);
-
     }
-
-
 
     pub fn get_pixel_ptr(&self) -> *const u32 {
-
         self.pixels.as_ptr()
-
     }
 
-
-
-    pub fn render(&mut self, settings_val: JsValue, freq_data: &[u8], _time: f64) -> Result<(), JsValue> {
-
+    pub fn render(
+        &mut self,
+        settings_val: JsValue,
+        freq_data: &[u8],
+        _time: f64,
+    ) -> Result<(), JsValue> {
         let settings: VibeSettings = serde_wasm_bindgen::from_value(settings_val)?;
 
         self.render_native(&settings, freq_data);
 
         Ok(())
-
     }
-
 }
 
-
-
 impl VibeEngine {
-
     pub fn get_pixel_slice(&self) -> &[u8] {
-
         unsafe {
-
-            std::slice::from_raw_parts(
-
-                self.pixels.as_ptr() as *const u8,
-
-                self.pixels.len() * 4
-
-            )
-
+            std::slice::from_raw_parts(self.pixels.as_ptr() as *const u8, self.pixels.len() * 4)
         }
-
     }
 
-
-
     pub fn render_native(&mut self, settings: &VibeSettings, freq_data: &[u8]) {
-
         // 1. Clear (Fast memset)
 
-        self.pixels.fill(0x00000000); 
-
-
+        self.pixels.fill(0x00000000);
 
         // 2. Physics
 
         self.update_physics(freq_data);
 
-
-
         // 3. Draw
 
-        match settings.visualizer_mode {
-
-            VisualizerMode::Bars => self.draw_bars(settings),
-
-            _ => (), // TODO
-
+        if let VisualizerMode::Bars = settings.visualizer_mode {
+            self.draw_bars(settings)
         }
-
     }
 
-
-
     fn update_physics(&mut self, freq_data: &[u8]) {
-
         let attack = 0.6;
 
         let decay = 0.12;
 
         let bar_count = 32;
 
-
-
         for i in 0..bar_count {
-
             let freq_index = (1.18f32.powf((i + 5) as f32)).floor() as usize;
 
             let mut target = 0.0;
 
-
-
             if freq_index < freq_data.len() {
-
                 let v1 = freq_data[freq_index] as f32;
 
-                let v2 = if freq_index + 1 < freq_data.len() { freq_data[freq_index + 1] as f32 } else { 0.0 };
+                let v2 = if freq_index + 1 < freq_data.len() {
+                    freq_data[freq_index + 1] as f32
+                } else {
+                    0.0
+                };
 
                 target = ((v1 + v2) / 2.0) / 255.0;
-
             }
 
-            
-
             target *= 1.3;
-
-
 
             let current = self.physics_state[i];
 
             let alpha = if target > current { attack } else { decay };
 
             self.physics_state[i] = current + (target - current) * alpha;
-
         }
-
     }
 
-
-
     fn draw_bars(&mut self, settings: &VibeSettings) {
-
         let padding = 80;
 
         let viz_width = 600;
@@ -194,56 +141,37 @@ impl VibeEngine {
 
         let origin_y = self.height - padding;
 
-        
+        let visible_bars: i32 = 12;
 
-        let visible_bars: i32 = 12; 
+        let bar_w: i32 = 24;
 
-        let bar_w: i32 = 24; 
-
-        let gap: i32 = 12; 
+        let gap: i32 = 12;
 
         let max_h = 200.0 * settings.visualizer_intensity;
 
-
-
         let color = self.hex_to_u32(&settings.visualizer_color);
 
-
-
         for i in 0..visible_bars {
-
             let idx = (i * 2) as usize;
 
             let val = self.physics_state[idx];
 
             let h = (val.powf(1.4) * max_h).max(4.0) as i32;
 
-
-
             let x = (origin_x + viz_width) - ((visible_bars - i) * (bar_w + gap));
 
             let y = origin_y - h;
 
-
-
             self.fill_rect(x, y, bar_w, h, color);
-
         }
-
     }
-
-
 
     // --- Rasterizer Helpers ---
 
-
-
     fn hex_to_u32(&self, hex: &str) -> u32 {
-
         // Expects #RRGGBB
 
         if hex.len() == 7 {
-
             let r = u8::from_str_radix(&hex[1..3], 16).unwrap_or(255);
 
             let g = u8::from_str_radix(&hex[3..5], 16).unwrap_or(255);
@@ -253,17 +181,12 @@ impl VibeEngine {
             // ABGR Little Endian
 
             return (255 << 24) | ((b as u32) << 16) | ((g as u32) << 8) | (r as u32);
-
         }
 
         0xFF03B7FF // Default Plasma (ABGR)
-
     }
 
-
-
     fn fill_rect(&mut self, x: i32, y: i32, w: i32, h: i32, color: u32) {
-
         // Clipping
 
         let x0 = x.max(0);
@@ -274,24 +197,16 @@ impl VibeEngine {
 
         let y1 = (y + h).min(self.height);
 
-
-
-        if x0 >= x1 || y0 >= y1 { return; }
-
-
+        if x0 >= x1 || y0 >= y1 {
+            return;
+        }
 
         for cy in y0..y1 {
-
             let start = (cy * self.width + x0) as usize;
 
             let end = (cy * self.width + x1) as usize;
 
             self.pixels[start..end].fill(color);
-
         }
-
     }
-
 }
-
-

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^4.0.15",
-    "wasm-pack": "^0.14.0"
+    "wasm-pack": "^0.13.1"
   },
   "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^4.0.15
         version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(jiti@1.21.7)(yaml@2.8.2)
       wasm-pack:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.13.1
+        version: 0.13.1
 
 packages:
 
@@ -1695,8 +1695,8 @@ packages:
       jsdom:
         optional: true
 
-  wasm-pack@0.14.0:
-    resolution: {integrity: sha512-7uKj+483b6ETTnuWHK3zKNB3Ca3M159tPZ5shyXxI4j7i9Lk82rL2ck/L6E9O5VMWk9JgowdtTBOSfWmGBRFtw==}
+  wasm-pack@0.13.1:
+    resolution: {integrity: sha512-P9exD4YkjpDbw68xUhF3MDm/CC/3eTmmthyG5bHJ56kalxOTewOunxTke4SyF8MTXV6jUtNjXggPgrGmMtczGg==}
     hasBin: true
 
   which@2.0.2:
@@ -3191,7 +3191,7 @@ snapshots:
       - tsx
       - yaml
 
-  wasm-pack@0.14.0:
+  wasm-pack@0.13.1:
     dependencies:
       binary-install: 1.1.2
     transitivePeerDependencies:

--- a/site/api/canary-config.js
+++ b/site/api/canary-config.js
@@ -1,0 +1,29 @@
+/* global process */
+
+function withoutTrailingSlash(value) {
+  return String(value || "").replace(/\/+$/, "");
+}
+
+function configuredValue(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export default function handler(_request, response) {
+  response.setHeader("Cache-Control", "no-store");
+
+  const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
+  const serverKey = configuredValue(process.env.CANARY_API_KEY);
+  const safeBrowserKey = browserKey && browserKey !== serverKey ? browserKey : null;
+
+  response.status(200).json({
+    service: "vibe-machine",
+    environment: process.env.PUBLIC_CANARY_ENVIRONMENT || process.env.VERCEL_ENV || "production",
+    endpoint: withoutTrailingSlash(
+      process.env.PUBLIC_CANARY_ENDPOINT ||
+        process.env.CANARY_ENDPOINT ||
+        "https://canary-obs.fly.dev"
+    ),
+    apiKey: safeBrowserKey,
+  });
+}

--- a/site/api/health.js
+++ b/site/api/health.js
@@ -1,0 +1,27 @@
+/* global process */
+
+function configuredValue(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export default function handler(_request, response) {
+  const serverKey = configuredValue(process.env.CANARY_API_KEY);
+  const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
+  const serverConfigured = serverKey !== null;
+  const browserConfigured = browserKey !== null;
+  const distinctBrowserKey = browserConfigured && browserKey !== serverKey;
+  const ok = serverConfigured && distinctBrowserKey;
+
+  response.setHeader("Cache-Control", "no-store");
+  response.status(200).json({
+    status: ok ? "ok" : "degraded",
+    service: "vibe-machine",
+    checks: {
+      canary: ok ? "configured" : "missing",
+      canaryServer: serverConfigured ? "configured" : "missing",
+      canaryBrowser: distinctBrowserKey ? "configured" : "missing",
+    },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/site/canary-observer.js
+++ b/site/canary-observer.js
@@ -1,0 +1,130 @@
+/* global fetch, window */
+
+const DEFAULT_CONFIG_PATH = "/api/canary-config";
+const OBSERVER_VERSION = "vibe-machine-site-v1";
+
+const REDACTION_RULES = [
+  [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]"],
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/g, "Bearer [redacted-token]"],
+  [/\bsk_(?:live|test)_[A-Za-z0-9_]+\b/g, "[redacted-key]"],
+  [
+    /https?:\/\/[^\s"'<>?]+(?:\?[^'"<>\s]*)/g,
+    (match) => match.replace(/\?.*$/, "?[redacted-query]"),
+  ],
+  [
+    /(^|[\s"'(])([/?#][^\s"'<>]*\?[^'"<>\s]*)/g,
+    (_match, prefix, path) => `${prefix}${path.replace(/\?.*$/, "?[redacted-query]")}`,
+  ],
+  [/\b[A-Za-z0-9_-]{32,}\b/g, "[redacted-token]"],
+];
+
+function asText(value) {
+  if (value instanceof Error) return value.message || value.name;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function redact(value) {
+  return REDACTION_RULES.reduce(
+    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+    asText(value)
+  );
+}
+
+export function normalizeError(input) {
+  const reason = input?.error || input?.reason;
+  const sourceError = reason instanceof Error ? reason : input instanceof Error ? input : null;
+  const messageSource = reason || input?.message || input;
+  const message = redact(asText(messageSource) || "Unhandled browser error");
+  const name = sourceError ? sourceError.name || "Error" : "Error";
+  const stack = sourceError?.stack ? redact(sourceError.stack) : undefined;
+
+  return { name, message, stack };
+}
+
+export function createPayload(config, input, page) {
+  const error = normalizeError(input);
+  const location = page?.location?.href || "";
+  const userAgent = page?.navigator?.userAgent || "";
+
+  return {
+    service: config.service || "vibe-machine",
+    environment: config.environment || "production",
+    severity: "error",
+    error_class: error.name,
+    message: error.message,
+    stack: error.stack,
+    source: "browser",
+    context: {
+      observer: OBSERVER_VERSION,
+      page_url: redact(location),
+      user_agent: redact(userAgent),
+    },
+  };
+}
+
+export async function loadConfig(fetchImpl = fetch, configPath = DEFAULT_CONFIG_PATH) {
+  const response = await fetchImpl(configPath, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+  if (!response.ok) return null;
+
+  const config = await response.json();
+  if (!config?.apiKey || !config?.endpoint) return null;
+
+  return {
+    service: config.service || "vibe-machine",
+    environment: config.environment || "production",
+    endpoint: String(config.endpoint).replace(/\/+$/, ""),
+    apiKey: config.apiKey,
+  };
+}
+
+export async function reportToCanary(config, payload, fetchImpl = fetch) {
+  if (!config?.apiKey || !config?.endpoint) return false;
+  const endpoint = String(config.endpoint).replace(/\/+$/, "");
+
+  const response = await fetchImpl(`${endpoint}/api/v1/errors`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  });
+
+  return response.ok;
+}
+
+export async function installCanaryObserver(options = {}) {
+  const page = options.window || window;
+  if (page.__vibeMachineCanaryObserverInstalled) return false;
+  page.__vibeMachineCanaryObserverInstalled = true;
+
+  const fetchImpl = options.fetch || page.fetch.bind(page);
+  const configPromise = options.configPromise || loadConfig(fetchImpl);
+
+  const capture = async (event) => {
+    try {
+      const config = await configPromise;
+      if (!config) return;
+      await reportToCanary(config, createPayload(config, event, page), fetchImpl);
+    } catch {
+      // Observability must never break the page it observes.
+    }
+  };
+
+  page.addEventListener("error", capture);
+  page.addEventListener("unhandledrejection", capture);
+  return true;
+}
+
+if (typeof window !== "undefined") {
+  installCanaryObserver();
+}

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Cinematic audio visualization for macOS. Your music, rendered."
     />
+    <script type="module" src="/canary-observer.js"></script>
     <style>
       @import url("https://fonts.googleapis.com/css2?family=Archivo+Black&display=swap");
 

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": null,
+  "installCommand": "true",
+  "buildCommand": null,
+  "outputDirectory": "."
+}

--- a/src-tauri/src/export_video.rs
+++ b/src-tauri/src/export_video.rs
@@ -287,7 +287,7 @@ pub async fn export_video(app: tauri::AppHandle, params: ExportParams) -> Result
         track_boundaries
             .iter()
             .position(|&boundary| time_secs < boundary)
-            .unwrap_or(track_boundaries.len().saturating_sub(1).max(0))
+            .unwrap_or(track_boundaries.len().saturating_sub(1))
     };
 
     for i in 0..total_frames {

--- a/tests/site-canary.test.ts
+++ b/tests/site-canary.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import configHandler from "../site/api/canary-config";
+import healthHandler from "../site/api/health";
+import {
+  createPayload,
+  installCanaryObserver,
+  loadConfig,
+  redact,
+  reportToCanary,
+} from "../site/canary-observer";
+
+type MockResponse = {
+  headers: Record<string, string>;
+  statusCode?: number;
+  body?: unknown;
+  setHeader(name: string, value: string): void;
+  status(code: number): MockResponse;
+  json(payload: unknown): MockResponse;
+};
+
+function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(env)) {
+    previous.set(key, process.env[key]);
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = env[key];
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function run(handler: (_request: unknown, response: MockResponse) => void) {
+  const response: MockResponse = {
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  handler({}, response);
+  return response;
+}
+
+describe("site Canary API", () => {
+  it("reports ok only when server and browser keys are configured and distinct", () => {
+    withEnv(
+      {
+        CANARY_API_KEY: "server-key",
+        PUBLIC_CANARY_API_KEY: "browser-key",
+      },
+      () => {
+        const result = run(healthHandler);
+
+        expect(result.statusCode).toBe(200);
+        expect(result.headers["Cache-Control"]).toBe("no-store");
+        expect(result.body).toMatchObject({
+          status: "ok",
+          service: "vibe-machine",
+          checks: {
+            canary: "configured",
+            canaryServer: "configured",
+            canaryBrowser: "configured",
+          },
+        });
+      }
+    );
+  });
+
+  it("treats whitespace-only keys as missing", () => {
+    withEnv(
+      {
+        CANARY_API_KEY: "   ",
+        PUBLIC_CANARY_API_KEY: "   ",
+      },
+      () => {
+        const health = run(healthHandler);
+        const config = run(configHandler);
+
+        expect(health.body).toMatchObject({
+          status: "degraded",
+          checks: {
+            canaryServer: "missing",
+            canaryBrowser: "missing",
+          },
+        });
+        expect(config.body).toMatchObject({ apiKey: null });
+      }
+    );
+  });
+
+  it("does not expose a browser key that matches the server key", () => {
+    withEnv(
+      {
+        CANARY_API_KEY: "same-key",
+        PUBLIC_CANARY_API_KEY: "same-key",
+      },
+      () => {
+        const config = run(configHandler);
+
+        expect(config.body).toMatchObject({
+          service: "vibe-machine",
+          apiKey: null,
+        });
+      }
+    );
+  });
+});
+
+describe("site Canary browser observer", () => {
+  it("redacts credentials and query strings", () => {
+    const output = redact(
+      [
+        "user@example.com",
+        "Bearer abc.def.ghi",
+        ["sk", "live", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_"),
+        "https://vibe.example.test/install?token=secret",
+        "/local?api_key=secret",
+        "abcdefghijklmnopqrstuvwxyz1234567890ABCDEF",
+      ].join(" ")
+    );
+
+    expect(output).toContain("[redacted-email]");
+    expect(output).toContain("[redacted-key]");
+    expect(output).toContain("[redacted-query]");
+    expect(output).not.toContain("user@example.com");
+    expect(output).not.toContain("abc.def.ghi");
+    expect(output).not.toContain("secret");
+  });
+
+  it("keeps the Vibe Machine service contract and preserves ErrorEvent messages", () => {
+    const payload = createPayload(
+      { service: "vibe-machine", environment: "production" },
+      { message: "script boom" },
+      {
+        location: { href: "https://vibe-machine-eight.vercel.app/?token=secret" },
+        navigator: { userAgent: "test-agent" },
+      }
+    );
+
+    expect(payload).toMatchObject({
+      service: "vibe-machine",
+      environment: "production",
+      error_class: "Error",
+      message: "script boom",
+    });
+    expect(payload.context.page_url).toBe(
+      "https://vibe-machine-eight.vercel.app/?[redacted-query]"
+    );
+  });
+
+  it("posts browser errors to Canary once installed", async () => {
+    const listeners = new Map<string, (event: unknown) => Promise<void>>();
+    const calls: Array<{ url: string; options: RequestInit }> = [];
+    const page = {
+      location: { href: "https://vibe-machine-eight.vercel.app/" },
+      navigator: { userAgent: "test-agent" },
+      fetch: async (url: string, options: RequestInit) => {
+        calls.push({ url, options });
+        return { ok: true };
+      },
+      addEventListener(type: string, listener: (event: unknown) => Promise<void>) {
+        listeners.set(type, listener);
+      },
+    };
+
+    const installed = await installCanaryObserver({
+      window: page,
+      configPromise: Promise.resolve({
+        service: "vibe-machine",
+        environment: "test",
+        endpoint: "https://canary.example.test/",
+        apiKey: "public-key",
+      }),
+    });
+    const secondInstall = await installCanaryObserver({ window: page });
+
+    await listeners.get("error")?.({ error: new Error("vibe smoke") });
+
+    expect(installed).toBe(true);
+    expect(secondInstall).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://canary.example.test/api/v1/errors");
+    expect(calls[0].options.method).toBe("POST");
+    expect(calls[0].options.headers).toMatchObject({
+      Authorization: "Bearer public-key",
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("ignores incomplete config", async () => {
+    const result = await loadConfig(
+      async () =>
+        ({
+          ok: true,
+          async json() {
+            return { endpoint: "https://canary.example.test", apiKey: "" };
+          },
+        }) as Response
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns false when reporting without a key", async () => {
+    await expect(reportToCanary({ endpoint: "https://canary.example.test" }, {})).resolves.toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Canary health/config endpoints for the static Vercel site
- install a browser error observer for service `vibe-machine`
- add Vitest coverage for config safety, redaction, payload creation, and observer capture
- clean up a clippy-blocking `single_match` in `vibe-engine` so the existing pre-push gate can pass

## Verification
- `pnpm test:run`
- `pnpm lint` (existing no-explicit-any warnings only)
- `pnpm type-check`
- `pnpm exec prettier --check site/index.html site/api/canary-config.js site/api/health.js site/canary-observer.js tests/site-canary.test.ts`
- `cargo clippy --manifest-path crates/vibe-engine/Cargo.toml -- -D warnings`
- repo pre-push hook passed
- local static smoke at `http://127.0.0.1:4179`
- fresh-context peer critic PASS

## Runtime config
- Vercel production and branch-preview Canary envs installed for `misty-step/vibe-machine`
- keys are service-bound ingest-only keys for `vibe-machine`; raw keys are not included here