### PR TITLE
fix(site): preserve parity on DigitalOcean

### DIFF
--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="plasma" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb703" />
+      <stop offset="100%" stop-color="#fb8500" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="128" fill="#030304" />
+  <path
+    d="M130 130 256 410 382 130"
+    fill="none"
+    stroke="url(#plasma)"
+    stroke-width="72"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,8 @@
       name="description"
       content="Cinematic audio visualization for macOS. Your music, rendered."
     />
+    <link rel="canonical" href="https://vibe-machine-fz976.ondigitalocean.app/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <script type="module" src="/canary-observer.js"></script>
     <style>
       @import url("https://fonts.googleapis.com/css2?family=Archivo+Black&display=swap");
@@ -332,7 +334,12 @@
 
       <div class="install">
         <code>brew install misty-step/tap/vibe-machine</code>
-        <button class="copy-btn" onclick="copyCommand(this)">
+        <button
+          class="copy-btn"
+          type="button"
+          aria-label="Copy install command"
+          onclick="copyCommand(this)"
+        >
           <svg
             class="icon-copy"
             viewBox="0 0 24 24"

--- a/site/package.json
+++ b/site/package.json
@@ -1,4 +1,10 @@
 {
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "engines": {
+    "node": "24.x"
+  }
 }

--- a/site/server.js
+++ b/site/server.js
@@ -2,7 +2,7 @@
 
 import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
-import { dirname, extname, join } from "node:path";
+import { dirname, extname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import canaryConfig from "./api/canary-config.js";
@@ -35,14 +35,17 @@ function apiResponse(response) {
 }
 
 async function serveFile(response, relativePath, headOnly) {
-  const segments = relativePath.split("/");
-  if (segments.some((segment) => segment === "..") || segments[0] === "api") {
+  const candidate = resolve(SITE_ROOT, relativePath);
+  if (
+    relativePath.startsWith("api/") ||
+    (candidate !== SITE_ROOT && !candidate.startsWith(`${SITE_ROOT}${sep}`))
+  ) {
     response.writeHead(404).end("Not found\n");
     return;
   }
 
   try {
-    const body = await readFile(join(SITE_ROOT, ...segments));
+    const body = await readFile(candidate);
     response.setHeader(
       "Content-Type",
       CONTENT_TYPES.get(extname(relativePath)) || "application/octet-stream"
@@ -67,16 +70,27 @@ export function createSiteServer() {
 
       const { pathname } = new URL(request.url || "/", "http://localhost");
       if (pathname === "/api/canary-config") {
-        canaryConfig(request, apiResponse(response));
+        await canaryConfig(request, apiResponse(response));
         return;
       }
       if (pathname === "/api/health") {
-        health(request, apiResponse(response));
+        await health(request, apiResponse(response));
         return;
       }
 
-      const decodedPath = decodeURIComponent(pathname);
-      const relativePath = decodedPath === "/" ? "index.html" : decodedPath.replace(/^\/+/, "");
+      let decodedPath;
+      try {
+        decodedPath = decodeURIComponent(pathname);
+      } catch {
+        response.writeHead(400).end("Bad request\n");
+        return;
+      }
+      const relativePath =
+        decodedPath === "/"
+          ? "index.html"
+          : decodedPath === "/favicon.ico"
+            ? "favicon.svg"
+            : decodedPath.replace(/^\/+/, "");
       await serveFile(response, relativePath, request.method === "HEAD");
     } catch {
       response.writeHead(500).end("Internal server error\n");

--- a/site/server.js
+++ b/site/server.js
@@ -1,0 +1,92 @@
+/* global URL, console, process */
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import canaryConfig from "./api/canary-config.js";
+import health from "./api/health.js";
+
+const SITE_ROOT = dirname(fileURLToPath(import.meta.url));
+const CONTENT_TYPES = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml; charset=utf-8"],
+]);
+
+function apiResponse(response) {
+  return {
+    setHeader(name, value) {
+      response.setHeader(name, value);
+    },
+    status(code) {
+      response.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      response.setHeader("Content-Type", "application/json; charset=utf-8");
+      response.end(JSON.stringify(payload));
+      return this;
+    },
+  };
+}
+
+async function serveFile(response, relativePath, headOnly) {
+  const segments = relativePath.split("/");
+  if (segments.some((segment) => segment === "..") || segments[0] === "api") {
+    response.writeHead(404).end("Not found\n");
+    return;
+  }
+
+  try {
+    const body = await readFile(join(SITE_ROOT, ...segments));
+    response.setHeader(
+      "Content-Type",
+      CONTENT_TYPES.get(extname(relativePath)) || "application/octet-stream"
+    );
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    response.statusCode = 200;
+    response.end(headOnly ? undefined : body);
+  } catch (error) {
+    if (error?.code !== "ENOENT" && error?.code !== "EISDIR") throw error;
+    response.writeHead(404).end("Not found\n");
+  }
+}
+
+export function createSiteServer() {
+  return createServer(async (request, response) => {
+    try {
+      if (request.method !== "GET" && request.method !== "HEAD") {
+        response.setHeader("Allow", "GET, HEAD");
+        response.writeHead(405).end("Method not allowed\n");
+        return;
+      }
+
+      const { pathname } = new URL(request.url || "/", "http://localhost");
+      if (pathname === "/api/canary-config") {
+        canaryConfig(request, apiResponse(response));
+        return;
+      }
+      if (pathname === "/api/health") {
+        health(request, apiResponse(response));
+        return;
+      }
+
+      const decodedPath = decodeURIComponent(pathname);
+      const relativePath = decodedPath === "/" ? "index.html" : decodedPath.replace(/^\/+/, "");
+      await serveFile(response, relativePath, request.method === "HEAD");
+    } catch {
+      response.writeHead(500).end("Internal server error\n");
+    }
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const port = Number.parseInt(process.env.PORT || "8080", 10);
+  createSiteServer().listen(port, "0.0.0.0", () => {
+    console.log(`vibe-machine site listening on ${port}`);
+  });
+}

--- a/tests/site-parity.test.ts
+++ b/tests/site-parity.test.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createSiteServer } from "../site/server";
+
+const CANONICAL_URL = "https://vibe-machine-fz976.ondigitalocean.app/";
+const servers: ReturnType<typeof createSiteServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve()))
+          )
+      )
+  );
+});
+
+async function startServer() {
+  const server = createSiteServer();
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+describe("DigitalOcean site parity", () => {
+  it("declares the DigitalOcean deployment canonical and labels the copy control", async () => {
+    const html = await readFile(new URL("../site/index.html", import.meta.url), "utf8");
+
+    expect(html).toContain(`<link rel="canonical" href="${CANONICAL_URL}" />`);
+    expect(html).toContain('<link rel="icon" type="image/svg+xml" href="/favicon.svg" />');
+    expect(html).toContain('aria-label="Copy install command"');
+  });
+
+  it("serves the site, favicon, and Canary API from one service", async () => {
+    const baseUrl = await startServer();
+
+    const [home, favicon, config, health] = await Promise.all([
+      fetch(`${baseUrl}/`),
+      fetch(`${baseUrl}/favicon.svg`),
+      fetch(`${baseUrl}/api/canary-config`),
+      fetch(`${baseUrl}/api/health`),
+    ]);
+
+    expect(home.status).toBe(200);
+    expect(home.headers.get("content-type")).toContain("text/html");
+    expect(favicon.status).toBe(200);
+    expect(favicon.headers.get("content-type")).toContain("image/svg+xml");
+    expect(config.status).toBe(200);
+    await expect(config.json()).resolves.toMatchObject({ service: "vibe-machine" });
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toMatchObject({ service: "vibe-machine" });
+  });
+
+  it("does not expose arbitrary files outside the site root", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/..%2Fpackage.json`);
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/site-parity.test.ts
+++ b/tests/site-parity.test.ts
@@ -41,9 +41,10 @@ describe("DigitalOcean site parity", () => {
   it("serves the site, favicon, and Canary API from one service", async () => {
     const baseUrl = await startServer();
 
-    const [home, favicon, config, health] = await Promise.all([
+    const [home, favicon, legacyFavicon, config, health] = await Promise.all([
       fetch(`${baseUrl}/`),
       fetch(`${baseUrl}/favicon.svg`),
+      fetch(`${baseUrl}/favicon.ico`),
       fetch(`${baseUrl}/api/canary-config`),
       fetch(`${baseUrl}/api/health`),
     ]);
@@ -52,6 +53,8 @@ describe("DigitalOcean site parity", () => {
     expect(home.headers.get("content-type")).toContain("text/html");
     expect(favicon.status).toBe(200);
     expect(favicon.headers.get("content-type")).toContain("image/svg+xml");
+    expect(legacyFavicon.status).toBe(200);
+    expect(legacyFavicon.headers.get("content-type")).toContain("image/svg+xml");
     expect(config.status).toBe(200);
     await expect(config.json()).resolves.toMatchObject({ service: "vibe-machine" });
     expect(health.status).toBe(200);
@@ -60,8 +63,12 @@ describe("DigitalOcean site parity", () => {
 
   it("does not expose arbitrary files outside the site root", async () => {
     const baseUrl = await startServer();
-    const response = await fetch(`${baseUrl}/..%2Fpackage.json`);
+    const attempts = await Promise.all([
+      fetch(`${baseUrl}/..%2Fpackage.json`),
+      fetch(`${baseUrl}/%2e%2e%2fpackage.json`),
+      fetch(`${baseUrl}/%E0%A4%A`),
+    ]);
 
-    expect(response.status).toBe(404);
+    expect(attempts.map(({ status }) => status)).toEqual([404, 404, 400]);
   });
 });


### PR DESCRIPTION
## Summary

- serve the landing page and existing Canary endpoints from one dependency-free Node service
- declare the DigitalOcean app canonical
- restore the favicon and accessible copy-button name
- add behavior-level parity and path-traversal tests

## Proof

- `pnpm build:wasm && pnpm format:check && pnpm lint && pnpm type-check && pnpm test:run`
- 24 tests pass; lint has only 3 pre-existing `no-explicit-any` warnings
- local server corpus: `/`, `/favicon.svg`, `/api/canary-config`, `/api/health`

## Migration boundary

This PR does not delete or reconfigure Vercel and does not mutate Canary. The DigitalOcean component conversion and live verification happen only after merge.

Agent: vibe-parity-codex
Agent-Surface: Codex
Agent-Model: openai/gpt-5
Agent-Task: vibe-migration-parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone site server for serving the website and health/configuration endpoints.
  - Added support for starting the site with a standard command and configurable port.
- **Accessibility**
  - Improved the install command copy button with an accessible label and explicit button behavior.
- **SEO & Branding**
  - Added canonical URL metadata and an SVG favicon.
- **Security**
  - Improved handling of unsupported methods and unsafe file paths.
- **Tests**
  - Added coverage for site rendering, endpoints, accessibility metadata, and path protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->