### PR TITLE
fix(site): health-check the active Canary reporter

### DIFF
--- a/site/api/health.js
+++ b/site/api/health.js
@@ -6,12 +6,9 @@ function configuredValue(value) {
 }
 
 export default function handler(_request, response) {
-  const serverKey = configuredValue(process.env.CANARY_API_KEY);
   const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
-  const serverConfigured = serverKey !== null;
   const browserConfigured = browserKey !== null;
-  const distinctBrowserKey = browserConfigured && browserKey !== serverKey;
-  const ok = serverConfigured && distinctBrowserKey;
+  const ok = browserConfigured;
 
   response.setHeader("Cache-Control", "no-store");
   response.status(200).json({
@@ -19,8 +16,7 @@ export default function handler(_request, response) {
     service: "vibe-machine",
     checks: {
       canary: ok ? "configured" : "missing",
-      canaryServer: serverConfigured ? "configured" : "missing",
-      canaryBrowser: distinctBrowserKey ? "configured" : "missing",
+      canaryBrowser: browserConfigured ? "configured" : "missing",
     },
     timestamp: new Date().toISOString(),
   });

--- a/site/api/health.js
+++ b/site/api/health.js
@@ -6,9 +6,10 @@ function configuredValue(value) {
 }
 
 export default function handler(_request, response) {
+  const serverKey = configuredValue(process.env.CANARY_API_KEY);
   const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
-  const browserConfigured = browserKey !== null;
-  const ok = browserConfigured;
+  const reporterConfigured = browserKey !== null && browserKey !== serverKey;
+  const ok = reporterConfigured;
 
   response.setHeader("Cache-Control", "no-store");
   response.status(200).json({
@@ -16,7 +17,7 @@ export default function handler(_request, response) {
     service: "vibe-machine",
     checks: {
       canary: ok ? "configured" : "missing",
-      canaryBrowser: browserConfigured ? "configured" : "missing",
+      canaryBrowser: reporterConfigured ? "configured" : "missing",
     },
     timestamp: new Date().toISOString(),
   });

--- a/tests/site-canary.test.ts
+++ b/tests/site-canary.test.ts
@@ -61,10 +61,10 @@ function run(handler: (_request: unknown, response: MockResponse) => void) {
 }
 
 describe("site Canary API", () => {
-  it("reports ok only when server and browser keys are configured and distinct", () => {
+  it("reports ok when the browser reporter key is configured", () => {
     withEnv(
       {
-        CANARY_API_KEY: "server-key",
+        CANARY_API_KEY: undefined,
         PUBLIC_CANARY_API_KEY: "browser-key",
       },
       () => {
@@ -77,7 +77,6 @@ describe("site Canary API", () => {
           service: "vibe-machine",
           checks: {
             canary: "configured",
-            canaryServer: "configured",
             canaryBrowser: "configured",
           },
         });
@@ -98,7 +97,6 @@ describe("site Canary API", () => {
         expect(health.body).toMatchObject({
           status: "degraded",
           checks: {
-            canaryServer: "missing",
             canaryBrowser: "missing",
           },
         });

--- a/tests/site-canary.test.ts
+++ b/tests/site-canary.test.ts
@@ -113,10 +113,15 @@ describe("site Canary API", () => {
       },
       () => {
         const config = run(configHandler);
+        const health = run(healthHandler);
 
         expect(config.body).toMatchObject({
           service: "vibe-machine",
           apiKey: null,
+        });
+        expect(health.body).toMatchObject({
+          status: "degraded",
+          checks: { canaryBrowser: "missing" },
         });
       }
     );


### PR DESCRIPTION
## Summary

Vibe Machine's landing page has a browser-side Canary reporter only. Make `/api/health` report the actual browser credential instead of requiring an unused server credential that Vercel cannot export during migration.

## Proof

- targeted Canary/parity suites: 11 tests pass
- full suite: 24 tests pass
- format, lint, typecheck, Rust check/clippy passed in pre-push gate
- no Canary mutation; the existing public ingest key will be copied directly from the live Vercel config into the DO secret

Agent: vibe-parity-codex
Agent-Surface: Codex
Agent-Model: openai/gpt-5
Agent-Task: vibe-migration-parity
