### PR TITLE
Cut site Canary fallback over to DigitalOcean

### DIFF
--- a/site/api/canary-config.js
+++ b/site/api/canary-config.js
@@ -18,11 +18,11 @@ export default function handler(_request, response) {
 
   response.status(200).json({
     service: "vibe-machine",
-    environment: process.env.PUBLIC_CANARY_ENVIRONMENT || process.env.VERCEL_ENV || "production",
+    environment: process.env.PUBLIC_CANARY_ENVIRONMENT || "production",
     endpoint: withoutTrailingSlash(
       process.env.PUBLIC_CANARY_ENDPOINT ||
         process.env.CANARY_ENDPOINT ||
-        "https://canary-obs.fly.dev"
+        "https://canary.mistystep.io"
     ),
     apiKey: safeBrowserKey,
   });

--- a/tests/site-canary.test.ts
+++ b/tests/site-canary.test.ts
@@ -126,6 +126,24 @@ describe("site Canary API", () => {
       }
     );
   });
+
+  it("defaults to the DigitalOcean Canary endpoint without Vercel runtime state", () => {
+    withEnv(
+      {
+        CANARY_ENDPOINT: undefined,
+        PUBLIC_CANARY_ENDPOINT: undefined,
+        PUBLIC_CANARY_ENVIRONMENT: undefined,
+        VERCEL_ENV: "preview",
+      },
+      () => {
+        const config = run(configHandler);
+        expect(config.body).toMatchObject({
+          endpoint: "https://canary.mistystep.io",
+          environment: "production",
+        });
+      }
+    );
+  });
 });
 
 describe("site Canary browser observer", () => {
@@ -154,7 +172,7 @@ describe("site Canary browser observer", () => {
       { service: "vibe-machine", environment: "production" },
       { message: "script boom" },
       {
-        location: { href: "https://vibe-machine-eight.vercel.app/?token=secret" },
+        location: { href: "https://vibe-machine-fz976.ondigitalocean.app/?token=secret" },
         navigator: { userAgent: "test-agent" },
       }
     );
@@ -166,7 +184,7 @@ describe("site Canary browser observer", () => {
       message: "script boom",
     });
     expect(payload.context.page_url).toBe(
-      "https://vibe-machine-eight.vercel.app/?[redacted-query]"
+      "https://vibe-machine-fz976.ondigitalocean.app/?[redacted-query]"
     );
   });
 
@@ -174,7 +192,7 @@ describe("site Canary browser observer", () => {
     const listeners = new Map<string, (event: unknown) => Promise<void>>();
     const calls: Array<{ url: string; options: RequestInit }> = [];
     const page = {
-      location: { href: "https://vibe-machine-eight.vercel.app/" },
+      location: { href: "https://vibe-machine-fz976.ondigitalocean.app/" },
       navigator: { userAgent: "test-agent" },
       fetch: async (url: string, options: RequestInit) => {
         calls.push({ url, options });


### PR DESCRIPTION
## Summary

- replaces the retired Fly Canary fallback with `https://canary.mistystep.io`
- removes Vercel runtime environment inference
- updates observer fixtures to the canonical DigitalOcean site origin

## Verification

- targeted site Canary suite: 9 passed
- format, lint, typecheck, and full Vitest suite: 27 passed
- old Fly host absent; `VERCEL_ENV` remains only as the negative regression input
- fresh-context critic: `BLOCKING: no`

Agent: codex-orchestrator
Agent-Surface: Codex
Agent-Task: bastion-921
