### PR TITLE
chore(site): retire Vercel deployment config

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,6 +1,0 @@
-{
-  "framework": null,
-  "installCommand": "true",
-  "buildCommand": null,
-  "outputDirectory": "."
-}

--- a/tests/provider-retirement.test.ts
+++ b/tests/provider-retirement.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, it } from "vitest";
 
 const root = process.cwd();
 const activeRoots = [
+  ".vercel",
   "AGENTS.md",
   "CLAUDE.md",
   "README.md",
   "package.json",
+  "vercel.json",
   ".github/workflows",
   "site",
 ];
@@ -29,6 +31,7 @@ describe("retired Vercel authority", () => {
       .map((path) => relative(root, path));
 
     expect(manifests).toEqual([]);
+    expect(existsSync(join(root, ".vercel"))).toBe(false);
   });
 
   it("has no active runtime or deployment authority", () => {

--- a/tests/provider-retirement.test.ts
+++ b/tests/provider-retirement.test.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const activeRoots = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "README.md",
+  "package.json",
+  ".github/workflows",
+  "site",
+];
+
+function files(path: string): string[] {
+  if (!existsSync(path)) return [];
+  if (/\.test\.[cm]?[jt]sx?$/.test(path)) return [];
+  if (!statSync(path).isDirectory()) return [path];
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) =>
+    files(join(path, entry.name))
+  );
+}
+
+describe("retired Vercel authority", () => {
+  it("has no active deployment manifest", () => {
+    const manifests = activeRoots
+      .flatMap((path) => files(join(root, path)))
+      .filter((path) => path.endsWith("vercel.json"))
+      .map((path) => relative(root, path));
+
+    expect(manifests).toEqual([]);
+  });
+
+  it("has no active runtime or deployment authority", () => {
+    const violations = activeRoots.flatMap((path) =>
+      files(join(root, path)).flatMap((file) =>
+        /\bvercel\b|@vercel\/|VERCEL_[A-Z_]+|\.vercel\.app\b/i.test(readFileSync(file, "utf8"))
+          ? [relative(root, file)]
+          : []
+      )
+    );
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Delete the final active site deployment manifest for the retired compute provider.
- Add a recursive regression test covering active site, workflow, package, and operator-doc surfaces.
- Preserve the historical release changelog entry as history.

## Verification

- pnpm format:check
- pnpm lint
- pnpm type-check
- pnpm test:run (29 tests)
- cargo clippy --manifest-path=src-tauri/Cargo.toml -- -D warnings
- cargo clippy --manifest-path=crates/vibe-engine/Cargo.toml -- -D warnings
- Live DigitalOcean root, health, and Canary config returned 200.

## Review focus

Confirm the guard covers every active static-site/runtime surface without treating CHANGELOG history as a rollback mechanism.

Agent: provider-retirement-implementer
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5
Agent-Task: DigitalOcean hard cutover