### PR TITLE
Allow explicit site bind address

### DIFF
--- a/site/server.js
+++ b/site/server.js
@@ -100,7 +100,8 @@ export function createSiteServer() {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const port = Number.parseInt(process.env.PORT || "8080", 10);
-  createSiteServer().listen(port, "0.0.0.0", () => {
-    console.log(`vibe-machine site listening on ${port}`);
+  const host = process.env.HOST || "0.0.0.0";
+  createSiteServer().listen(port, host, () => {
+    console.log(`vibe-machine site listening on ${host}:${port}`);
   });
 }


### PR DESCRIPTION
## Outcome

Allow the production Node site server bind address to be set with `HOST`. The existing `0.0.0.0` default remains unchanged for App Platform and rollback safety. The shared-host systemd unit sets `HOST=127.0.0.1`, keeping Caddy as its only public listener.

## Evidence

- `pnpm exec vitest run tests/site-parity.test.ts`
- Runtime smoke with `HOST=127.0.0.1` observed `127.0.0.1:48080` and a responding `/api/health` route.

## Unchanged

App Platform does not set `HOST`, so its current and rollback deployments continue binding `0.0.0.0`. The exported `createSiteServer()` test interface is unchanged.